### PR TITLE
Edit crisis button appearance and content

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -9,11 +9,11 @@
             <button mat-button id="rsrc" [routerLink]="['/resources']" routerLinkActive="nav-active" [routerLinkActiveOptions]="{exact: true}"><mat-icon><i class="material-icons">format_list_numbered</i></mat-icon>Resources</button>
             <button mat-button id="rep" [routerLink]="['/reports']" routerLinkActive="nav-active" [routerLinkActiveOptions]="{exact: true}"><mat-icon><i class="material-icons">assessment</i></mat-icon>Reports</button>
             <button mat-button id="goals" [routerLink]="['/goals']" routerLinkActive="nav-active" [routerLinkActiveOptions]="{exact: true}"><mat-icon><i class="material-icons">accessibility</i></mat-icon>Goals</button>
-            <button mat-raised-button color="warn" id="crisisButton" (click)="openDialog()"><mat-icon class="icons">local_phone</mat-icon>Crisis Button</button>
+            <button mat-raised-button color="warn" id="crisisButton" (click)="openDialog()">Crisis</button>
         </div>
 
         <button mat-button [mat-menu-trigger-for]="menu" fxHide="false" fxHide.gt-sm><mat-icon>menu</mat-icon></button>
-        <button mat-raised-button color="warn" (click)="openDialog()" [mat-menu-trigger-for]="menu" fxHide="false" fxHide.gt-sm><mat-icon class="icons">local_phone</mat-icon>Crisis Button</button>
+        <button mat-raised-button color="warn" (click)="openDialog()" [mat-menu-trigger-for]="menu" fxHide="false" fxHide.gt-sm>Crisis</button>
     </mat-toolbar>
 
     <mat-menu x-position="before" #menu="matMenu">

--- a/client/src/app/home/crisis-button.component.html
+++ b/client/src/app/home/crisis-button.component.html
@@ -1,16 +1,16 @@
 <div class="crisis-button" layout-gt-sm="row">
     <div flex-gt-sm="80" flex-offset-gt-sm="10">
-        <mat-card-title>Crisis Button</mat-card-title>
+        <mat-card-title>Crisis</mat-card-title>
         <mat-card>
             <mat-card-content>
-                Emergency Contact #1
+                Crisis Hotline: 775-784-8090
             </mat-card-content>
-            <mat-card-content>
+           <!-- <mat-card-content>
                 Emergency Contact #2
             </mat-card-content>
             <mat-card-content>
                 Emergency Contact #3
-            </mat-card-content>
+            </mat-card-content>-->
             <button mat-raised-button id="exitWithoutAddingButton" (click)="onNoClick()" type="button">Exit</button>
         </mat-card>
     </div>


### PR DESCRIPTION
-Button looks better and is no longer redundant
-Instead of placeholders, once clicked, the button has a dialogue with the crisis hotline and phone number.